### PR TITLE
Be more annoying.

### DIFF
--- a/config.ini.example
+++ b/config.ini.example
@@ -6,7 +6,7 @@ authtoken=XXXXXXX
 channel=journal
 
 # Reminder sent out at the reminder_time (in %H:%M format---24 hrs)
-reminder=Folks, don't forget to post a short update for today!
+reminder=@channel: Folks, don't forget to post a short update for today!
 reminder_time=17:30
 
 # Warning sent out at the warning_time (in %H:%M format---24hrs)


### PR DESCRIPTION
@channel posts a ping to everyone in that channel, which is more annoying/noticeable than a simple message.

@everyone regrettably only works in the #general equivalent channel, but will reach them even if they've left a channel.